### PR TITLE
qcom.power.rc: changes to match init.caesium.rc

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -35,17 +35,17 @@ on enable-low-power
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_sched_load 1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 19000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 90
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 960000
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 0
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 95
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 30000
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 0
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads 80
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 19000
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "70 691200:45 844800:50 1056000:60 1286400:70 1440000:85 1516800:95"
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 60000
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis 79000
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 300000
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 307200
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/ignore_hispeed_on_notif 0
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/enable_prediction 1
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/enable_prediction 0
 
     # Online CPU2
     write /sys/devices/system/cpu/cpu2/online 1
@@ -54,23 +54,27 @@ on enable-low-power
     write /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor "interactive"
     write /sys/devices/system/cpu/cpu2/cpufreq/interactive/use_sched_load 1
     write /sys/devices/system/cpu/cpu2/cpufreq/interactive/use_migration_notif 1
-    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/above_hispeed_delay "19000 1400000:39000 1700000:39000 2100000:79000"
+    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/above_hispeed_delay "19000 1400000:39000 1700000:19000 2100000:79000"
     write /sys/devices/system/cpu/cpu2/cpufreq/interactive/go_hispeed_load 90
-    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/timer_rate 20000
-    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/hispeed_freq 1248000
+    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/timer_rate 30000
+    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/hispeed_freq 825600
     write /sys/devices/system/cpu/cpu2/cpufreq/interactive/io_is_busy 1
-    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/target_loads "85 1500000:90 1800000:95 2100000:99"
+    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/target_loads "85 1593600:80 1824000:90 2150400:95"
     write /sys/devices/system/cpu/cpu2/cpufreq/interactive/min_sample_time 19000
     write /sys/devices/system/cpu/cpu2/cpufreq/interactive/max_freq_hysteresis 39000
-    write /sys/devices/system/cpu/cpu2/cpufreq/scaling_min_freq 300000
+    write /sys/devices/system/cpu/cpu2/cpufreq/scaling_min_freq 307200
     write /sys/devices/system/cpu/cpu2/cpufreq/interactive/ignore_hispeed_on_notif 0
-    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/enable_prediction 1
+    write /sys/devices/system/cpu/cpu2/cpufreq/interactive/enable_prediction 0
 
-    # Re-enable thermal hotplug
-    write /sys/module/msm_thermal/core_control/enabled 1
+    # MSM Thermal thresholds
+    write  /sys/module/msm_thermal/parameters/enabled Y
+    write  /sys/module/msm_thermal/core_control/enabled 0
+    write  /sys/module/msm_thermal/parameters/temp_threshold 50
+    write  /sys/module/msm_thermal/parameters/core_limit_temp_degC 60
 
     # Input boost configuration
-    write /sys/module/cpu_boost/parameters/input_boost_freq "0:1324800 2:1324800"
+    write /sys/module/cpu_boost/parameters/input_boost_enabled 0
+    write /sys/module/cpu_boost/parameters/input_boost_freq "0:979200 2:825600"
     write /sys/module/cpu_boost/parameters/input_boost_ms 40
 
     # Setting b.L scheduler parameters
@@ -123,7 +127,14 @@ on enable-low-power
     # Set perfd properties
     setprop sys.post_boot.parsed 1
 
-    setprop sys.io.scheduler "bfq"
+    setprop sys.io.scheduler "cfq"
+
+    # Tune the sda block
+    write  /sys/block/sda/queue/read_ahead_kb 128
+    write  /sys/block/sda/queue/iosched/back_seek_penalty 4
+    write  /sys/block/sda/queue/iosched/low_latency 0
+    write  /sys/block/sda/queue/iosched/target_latency_us 300
+
     # update cpusets now that boot is complete and we want better load balancing
     write /dev/cpuset/top-app/cpus 0-3
     write /dev/cpuset/foreground/boost/cpus 0-2
@@ -144,6 +155,12 @@ on charger
     write /sys/devices/soc/${ro.boot.bootdevice}/${ro.boot.bootdevice}:ufs_variant/pm_qos_enable 1
     write /sys/module/lpm_levels/parameters/sleep_disabled 0
     start dashd
+
+    # Hardware keys backlight control
+on property:persist.hwkeys.backlight=enabled
+    write /sys/class/leds/button-backlight/max_brightness 40
+on property:persist.hwkeys.backlight=disabled
+    write /sys/class/leds/button-backlight/max_brightness 0
 
 on property:init.svc.recovery=running
     trigger enable-low-power


### PR DESCRIPTION
we are using caesium kernel as our base, so we want these settings as well. 

this contains the following changes:
- disable input boost by default
- change to cfq as default iosched
- adjusting interactive gov freq scaling, load parameters, timer_rate and so on
- import msm thermal thresholds
- tune the sda block
- add hardware keys backlight control parameters
- disable prediction (causes problems on oreo)

taken from: https://github.com/MSF-Jarvis/AnyKernel2/blob/8.1.x-caesium/ramdisk/init.caesium.rc